### PR TITLE
Handle HTTP 405 status in Algorand SDK

### DIFF
--- a/sdk/_namespace_based/Algorand/algod.php
+++ b/sdk/_namespace_based/Algorand/algod.php
@@ -202,7 +202,7 @@ class algod {
                 case 404:
                     $this->error = 'NOT FOUND';
                     break;
-                case 404:
+                case 405:
                     $this->error = 'NOT ALLOWED';
                     break;
             }

--- a/sdk/_namespace_based/Algorand/kmd.php
+++ b/sdk/_namespace_based/Algorand/kmd.php
@@ -194,7 +194,7 @@ class kmd
                     $this->error = 'NOT FOUND';
                     break;
 
-                case 404:
+                case 405:
                     $this->error = 'NOT ALLOWED';
                     break;
 

--- a/sdk/algorand.php
+++ b/sdk/algorand.php
@@ -199,7 +199,7 @@ class Algorand_algod {
                 case 404:
                     $this->error = 'NOT FOUND';
                     break;
-                case 404:
+                case 405:
                     $this->error = 'NOT ALLOWED';
                     break;
             }
@@ -418,7 +418,7 @@ class Algorand_kmd
                     $this->error = 'NOT FOUND';
                     break;
 
-                case 404:
+                case 405:
                     $this->error = 'NOT ALLOWED';
                     break;
 


### PR DESCRIPTION
## Summary
- fix duplicate 404 handling so HTTP 405 (Not Allowed) is surfaced correctly in Algorand and KMD clients
- apply same fix in namespaced Algorand SDK classes

## Testing
- `php -r 'require "sdk/algorand.php"; $a=new Algorand_algod("", "127.0.0.1", 8000); $r=$a->get("405.php"); var_export([$r["code"], $a->error, $r["message"]]);'`
- `php -r 'require "sdk/algorand.php"; $a=new Algorand_kmd("", "127.0.0.1", 8000); $r=$a->get("405.php"); var_export([$r["code"], $a->error, $r["message"]]);'`
- `php /tmp/test_namespace_algod.php`
- `php /tmp/test_namespace_kmd.php`


------
https://chatgpt.com/codex/tasks/task_e_68b4064017d88326bcdcfc52e7cd2dfb